### PR TITLE
Update vttConvert in case last elem without 'start_time'

### DIFF
--- a/lib/vttConvert.js
+++ b/lib/vttConvert.js
@@ -39,7 +39,10 @@ class VttConvert
                 vtt += formatted_start + ' --> ' + formatted_end + '\n';
                 vtt += nextline + '\n\n';
                 nextline = '';
-                current_start = json.results.items[index + 1].start_time;
+                // in case od current element is the last one
+                if (index < (json.results.items.length - 1)) {
+                    current_start = json.results.items[index + 1].start_time;
+                }
             } else if (item.end_time - current_start > 5) {
                 helpers.secondsToMinutes(current_start, (err, res) => {formatted_start = res;});
                 helpers.secondsToMinutes(json.results.items[index - 1].end_time, (err, res) => {formatted_end = res;});


### PR DESCRIPTION
Sometimes last element of json file doesn't have element "start_time".
So i added little fix to solve this problem.
Example of such an element at the end of transcribed json file
```
		{
			"start_time": "2497.456",
			"end_time": "2497.766",
			"alternatives": [{
				"confidence": "0.9190",
				"content": "right"
			}],
			"type": "pronunciation"
		},
		{
			"alternatives": [{
				"content": "."
			}],
			"type": "punctuation"
		}]
	},
	"status": "COMPLETED"
}
```